### PR TITLE
pass credentials to jobs from config YAML

### DIFF
--- a/lib/open_fn/credential.ex
+++ b/lib/open_fn/credential.ex
@@ -1,10 +1,7 @@
-defmodule OpenFn.Job do
+defmodule OpenFn.Credential do
   defstruct [
     :name,
-    :expression,
-    :credential,
-    :language_pack,
-    :trigger
+    :body
   ]
 
   def new(fields \\ []) do

--- a/lib/open_fn/run_broadcaster.ex
+++ b/lib/open_fn/run_broadcaster.ex
@@ -55,7 +55,13 @@ defmodule OpenFn.RunBroadcaster do
     runs =
       Config.jobs_for(config, triggers)
       |> Enum.map(fn job ->
-        Run.new(job: job, initial_state: %{"data" => message.body})
+        Run.new(
+          job: job,
+          initial_state: %{
+            "data" => message.body,
+            "configuration" => Config.credential_body_for(config, job)
+          }
+        )
       end)
 
     runs |> Enum.each(&RunDispatcher.invoke_run(run_dispatcher, &1))
@@ -82,10 +88,7 @@ defmodule OpenFn.RunBroadcaster do
               %{}
           end
 
-        # TODO: credentials
-        next_state = %{}
-
-        IO.inspect([source_state, next_state])
+        next_state = %{"configuration" => Config.credential_body_for(config, job)}
 
         initial_state = merge_states([source_state, next_state])
 
@@ -119,8 +122,7 @@ defmodule OpenFn.RunBroadcaster do
               %{}
           end
 
-        # TODO: credentials
-        next_state = %{}
+        next_state = %{"configuration" => Config.credential_body_for(config, job)}
 
         initial_state = merge_states([source_state, next_state])
 

--- a/test/fixtures/project_config.yaml
+++ b/test/fixtures/project_config.yaml
@@ -5,11 +5,11 @@ jobs:
         console.log("Hi there!")
         return state;
       })
-    language_pack: '@openfn/language-common'
+    language_pack: "@openfn/language-common"
     trigger: trigger-2
   job-2:
     expression: none
-    language_pack: '@openfn/language-common'
+    language_pack: "@openfn/language-common"
     trigger: trigger-3
   job-3:
     expression: >
@@ -17,7 +17,7 @@ jobs:
         console.log("Hi there!")
         return state;
       })
-    language_pack: '@openfn/language-common'
+    language_pack: "@openfn/language-common"
     trigger: trigger-4
 
 triggers:
@@ -26,7 +26,11 @@ triggers:
   trigger-3:
     criteria: '{"b":2}'
   trigger-4:
-    cron: '* * * * *'
+    cron: "* * * * *"
   after-job-2:
-    success:  job-2
-      
+    success: job-2
+
+credentials:
+  credential-1:
+    username: "sample@example.com"
+    password: "shhh"

--- a/test/open_fn/run_broadcaster_test.exs
+++ b/test/open_fn/run_broadcaster_test.exs
@@ -9,6 +9,7 @@ defmodule OpenFn.RunBroadcaster.UnitTest do
     CronTrigger,
     FlowTrigger,
     Job,
+    Credential,
     Run
   }
 
@@ -17,8 +18,12 @@ defmodule OpenFn.RunBroadcaster.UnitTest do
 
     config =
       Config.new(
+        credentials: [
+          test_credential =
+            Credential.new(name: "test-credential", body: %{username: "un", password: "pw"})
+        ],
         jobs: [
-          test_job = Job.new(name: "test-job", trigger: "test"),
+          test_job = Job.new(name: "test-job", trigger: "test", credential: "test-credential"),
           cron_job = Job.new(name: "cron-job", trigger: "cron-trigger"),
           success_flow_job = Job.new(name: "flow-job", trigger: "after-test-job"),
           failure_flow_job = Job.new(name: "flow-job-failure", trigger: "after-test-job-failure")
@@ -63,7 +68,8 @@ defmodule OpenFn.RunBroadcaster.UnitTest do
       cron_job: cron_job,
       success_flow_job: success_flow_job,
       failure_flow_job: failure_flow_job,
-      test_job: test_job
+      test_job: test_job,
+      test_credential: test_credential
     }
   end
 


### PR DESCRIPTION
@stuartc , there are a couple of things to discuss here, but I'm happy with the initial (if brittle) outcome.

1. in our project spec, jobs should have a `credential` key. (when preparing `state`, we set `"configuration" => credential_body_for(config, job)` but that JSON key shouldn't be conflated with the project _spec_, in my opinion.
2. where should that function live? i've put it inside `Config` for now.
3. we need to beef up test on all the edge cases... i figure as we start wiring this up for implementation in WP1/WP3 and the DS stuff we'll expand those naturally with real use cases. for this one, project specs _and_ jobs themselves should be able to completely omit `credentials`/`credential` from the yaml.