### PR TITLE
Log Streaming

### DIFF
--- a/lib/open_fn/log_stream.ex
+++ b/lib/open_fn/log_stream.ex
@@ -1,0 +1,63 @@
+  defmodule OpenFn.LogStream do
+    @moduledoc """
+    Creates a Stream with an accompanying callback function to add log lines
+    as the process is running.
+
+    Included in the processing, is a reducer that deals with incomplete
+    UTF-8 bitstrings. For example when a 64 byte message comes in and the last
+    byte is the first of a 4-byte character; `IO.iodata_to_binary/1` raises
+    an exception.
+
+    The stream will only emit values when they are valid UTF-8 binaries.
+
+    _NOTE_: The processing is eager, it doesn't wait until a new-line character
+    before emitting a value. This can be handled further down-stream if needed.
+    """
+
+    def create(parent \\ self()) do
+      line_stream =
+        Stream.resource(fn -> {"", ""} end, &loop/1, fn _ -> nil end)
+
+      callback = fn msg -> send(parent, msg) end
+
+      {line_stream, callback}
+    end
+
+    defp loop({partial_chunk, pending}) do
+      receive do
+        {_type, data} ->
+          process_chunk(data, {partial_chunk, pending})
+          |> case do
+            {nil, partial_chunk, pending} ->
+              {[], {partial_chunk, pending}}
+
+            {chunk, "", pending} ->
+              {[chunk], {"", pending}}
+          end
+
+        :complete ->
+          {:halt, pending}
+      end
+    end
+
+    defp process_chunk(data, {partial, pending}) do
+      next = pending <> data
+
+      Enum.reduce_while(
+        0..byte_size(next),
+        {partial, String.next_grapheme(next)},
+        fn _, {chunk, grapheme_result} ->
+          case grapheme_result do
+            {<<_::utf8>> = next_char, rest} ->
+              {:cont, {chunk <> IO.iodata_to_binary(next_char), String.next_grapheme(rest)}}
+
+            {next_char, rest} ->
+              {:halt, {nil, chunk, next_char <> rest}}
+
+            nil ->
+              {:halt, {chunk, "", ""}}
+          end
+        end
+      )
+    end
+  end

--- a/lib/open_fn/run.ex
+++ b/lib/open_fn/run.ex
@@ -43,6 +43,6 @@ defmodule OpenFn.Run do
   end
 
   def add_log_line(%{log: log} = run, {type, line}) do
-    %{run | log: [{type, line} | log]}
+    %{run | log: Enum.concat(log, [{type, line}])}
   end
 end

--- a/lib/open_fn/run_dispatcher.ex
+++ b/lib/open_fn/run_dispatcher.ex
@@ -36,7 +36,6 @@ defmodule OpenFn.RunDispatcher do
       File.mkdir_p!(basedir)
     end
 
-    IO.puts("RunDispatcher started")
     {:ok, opts}
   end
 
@@ -60,6 +59,7 @@ defmodule OpenFn.RunDispatcher do
       receive do
         {:run_complete, run} ->
           RunBroadcaster.process(state.run_broadcaster, run)
+
         {:DOWN, _ref, :process, ^pid, :normal} ->
           nil
       end

--- a/test/open_fn/shell_runtime_test.exs
+++ b/test/open_fn/shell_runtime_test.exs
@@ -8,44 +8,24 @@ defmodule OpenFn.ShellRuntimeTest do
     {:ok, %Rambo{}} = OpenFn.ShellRuntime.run(%RunSpec{})
   end
 
-  test "can deal with bitstrings" do
-    {:ok, agent} = Agent.start_link(fn -> {[], "", ""} end)
+  test "when used with LogStream" do
+    {line_stream, stream_callback} = OpenFn.LogStream.create()
 
-    f = fn {_type, data} ->
-      Agent.update(agent, fn {lines, current_chunk, pending} ->
-        next_chunk = pending <> data
-
-        {state, chunk, pending} =
-          Enum.reduce_while(
-            0..byte_size(next_chunk),
-            {current_chunk, String.next_grapheme(next_chunk)},
-            fn _, {chunk, grapheme_result} ->
-              case grapheme_result do
-                {<<_::utf8>> = next_char, rest} ->
-                  {:cont, {chunk <> IO.iodata_to_binary(next_char), String.next_grapheme(rest)}}
-
-                {next_char, rest} ->
-                  {:halt, {:incomplete, chunk, next_char <> rest}}
-
-                nil ->
-                  {:halt, {:done, chunk, ""}}
-              end
-            end
-          )
-
-        case state do
-          :incomplete ->
-            {lines, chunk, pending}
-
-          :done ->
-            {lines ++ [chunk], nil, pending}
-        end
+    task =
+      Task.async(fn ->
+        Rambo.run("echo", [String.duplicate(".", 63) <> "💣"], log: stream_callback)
+        Process.sleep(100)
+        Rambo.run("echo", [String.duplicate(".", 63) <> "💣\n"], log: stream_callback)
+        Rambo.run("echo", [String.duplicate(".", 63) <> "💣"], log: stream_callback)
+        stream_callback.(:complete)
       end)
-    end
 
-    Rambo.run("echo", [String.duplicate(".", 63) <> "💣"], log: f)
+    assert line_stream |> Enum.into([]) == [
+             "...............................................................💣\n",
+             "...............................................................💣\n\n",
+             "...............................................................💣\n"
+           ]
 
-    assert Agent.get(agent, fn value -> value end) ==
-             {["...............................................................💣\n"], nil, ""}
+    Task.await(task)
   end
 end

--- a/test/open_fn/shell_runtime_test.exs
+++ b/test/open_fn/shell_runtime_test.exs
@@ -3,7 +3,49 @@ defmodule OpenFn.ShellRuntimeTest do
 
   alias OpenFn.RunSpec
 
-  # test "works" do
-  #   {:ok, %Rambo{}} = OpenFn.ShellRuntime.run(%RunSpec{})
-  # end
+  @tag skip: true
+  test "works" do
+    {:ok, %Rambo{}} = OpenFn.ShellRuntime.run(%RunSpec{})
+  end
+
+  test "can deal with bitstrings" do
+    {:ok, agent} = Agent.start_link(fn -> {[], "", ""} end)
+
+    f = fn {_type, data} ->
+      Agent.update(agent, fn {lines, current_chunk, pending} ->
+        next_chunk = pending <> data
+
+        {state, chunk, pending} =
+          Enum.reduce_while(
+            0..byte_size(next_chunk),
+            {current_chunk, String.next_grapheme(next_chunk)},
+            fn _, {chunk, grapheme_result} ->
+              case grapheme_result do
+                {<<_::utf8>> = next_char, rest} ->
+                  {:cont, {chunk <> IO.iodata_to_binary(next_char), String.next_grapheme(rest)}}
+
+                {next_char, rest} ->
+                  {:halt, {:incomplete, chunk, next_char <> rest}}
+
+                nil ->
+                  {:halt, {:done, chunk, ""}}
+              end
+            end
+          )
+
+        case state do
+          :incomplete ->
+            {lines, chunk, pending}
+
+          :done ->
+            {lines ++ [chunk], nil, pending}
+        end
+      end)
+    end
+
+    Rambo.run("echo", [String.duplicate(".", 63) <> "💣"], log: f)
+
+    assert Agent.get(agent, fn value -> value end) ==
+             {["...............................................................💣\n"], nil, ""}
+  end
 end


### PR DESCRIPTION
Adding the ability to turn log messages (from Rambo at present) into a stream.
In order to deal with the chunked nature of io streams from processes, there is a 
_smart'ish_ buffer that won't emit values until they are valid UTF-8.

**TODO**

- [x] Integrate back into `RunDispatcher` and `RunTask`.
- [x] Consider changing the emit criteria to be on `"\n"` new line charactors.
- [ ] ~~Consider allowing the distinction between `:stdout` and `:stderr`, currently it just jams them together.~~